### PR TITLE
Fix clockwork Architectury dependency crash in code editor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     runtimeOnly fg.deobf("maven.modrinth:create-clockwork:Bk2kwZr0")
     
 //    runtimeOnly fg.deobf("maven.modrinth:vmod:mGgUMpre")
-//    runtimeOnly fg.deobf("maven.modrinth:architectury-api:1MKTLiiG")
+    runtimeOnly fg.deobf("maven.modrinth:architectury-api:1MKTLiiG")
 
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html


### PR DESCRIPTION
When trying to render the wanderwand clockwork will crash the game without Architectury