### PR TITLE
add MixinLecternControllerBlockEntity to ensure LecternControllerBlockEntity has the tag Hub

### DIFF
--- a/src/main/java/edn/stratodonut/drivebywire/mixin/compat/MixinLecternControllerBlockEntity.java
+++ b/src/main/java/edn/stratodonut/drivebywire/mixin/compat/MixinLecternControllerBlockEntity.java
@@ -1,0 +1,61 @@
+package edn.stratodonut.drivebywire.mixin.compat;
+
+import com.simibubi.create.AllItems;
+import com.simibubi.create.content.redstone.link.controller.LecternControllerBlockEntity;
+import edn.stratodonut.drivebywire.util.HubItem;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static edn.stratodonut.drivebywire.util.HubItem.TAG;
+
+@Mixin(LecternControllerBlockEntity.class)
+public class MixinLecternControllerBlockEntity {
+
+    @Unique
+    private BlockPos drivebywire$blockPos;
+
+    @Inject(method = "read", at = @At("RETURN"), remap = false)
+    private void read(CompoundTag compound, boolean clientPacket, CallbackInfo ci) {
+        if (compound.contains(TAG)) {
+            this.drivebywire$blockPos = BlockPos.of(compound.getLong(TAG));
+        }
+    }
+
+    @Inject(method = "write", at = @At("TAIL"), remap = false)
+    private void write(CompoundTag compound, boolean clientPacket, CallbackInfo ci) {
+        if (this.drivebywire$blockPos != null) {
+            compound.putLong(TAG, this.drivebywire$blockPos.asLong());
+        }
+    }
+
+    @Inject(method = "writeSafe", at = @At("TAIL"), remap = false)
+    private void writeSafe(CompoundTag compound, CallbackInfo ci) {
+        if (this.drivebywire$blockPos != null) {
+            compound.putLong(TAG, this.drivebywire$blockPos.asLong());
+        }
+    }
+
+    @Inject(method = "setController", at = @At("HEAD"), remap = false)
+    private void setController(ItemStack newController, CallbackInfo ci) {
+        if (newController != null && AllItems.LINKED_CONTROLLER.get() == newController.getItem()) {
+            HubItem.ifHubPresent(newController, (pos) -> this.drivebywire$blockPos = pos);
+        }
+    }
+
+    // the oldest version 0.5.1 don't have the method, so set require 0
+    @Inject(method = "createLinkedController", at = @At("RETURN"), remap = false, require = 0)
+    private void createLinkedController(CallbackInfoReturnable<ItemStack> cir) {
+        ItemStack stack = cir.getReturnValue();
+        if ((stack.hasTag() && !stack.getTag().contains(TAG, Tag.TAG_LONG)) && this.drivebywire$blockPos != null) {
+            HubItem.putHub(stack, this.drivebywire$blockPos);
+        }
+    }
+}

--- a/src/main/java/edn/stratodonut/drivebywire/util/HubItem.java
+++ b/src/main/java/edn/stratodonut/drivebywire/util/HubItem.java
@@ -8,15 +8,17 @@ import net.minecraft.world.item.ItemStack;
 import java.util.function.Consumer;
 
 public class HubItem {
+    public static String TAG = "Hub";
+
     public static void putHub(ItemStack itemStack, BlockPos pos) {
         CompoundTag nbt = itemStack.getOrCreateTag();
-        nbt.putLong("Hub", pos.asLong());
+        nbt.putLong(TAG, pos.asLong());
         itemStack.setTag(nbt);
     }
     
     public static void ifHubPresent(ItemStack itemStack, Consumer<BlockPos> runnable) {
-        if (itemStack.hasTag() && itemStack.getTag().contains("Hub", Tag.TAG_LONG)) {
-            runnable.accept(BlockPos.of(itemStack.getTag().getLong("Hub")));
+        if (itemStack.hasTag() && itemStack.getTag().contains(TAG, Tag.TAG_LONG)) {
+            runnable.accept(BlockPos.of(itemStack.getTag().getLong(TAG)));
         }
     }
 }

--- a/src/main/resources/drivebywire.mixins.json
+++ b/src/main/resources/drivebywire.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "MixinServerLevel",
     "compat.MixinLecternControllerBlock",
+    "compat.MixinLecternControllerBlockEntity",
     "compat.MixinLinkedControllerInputPacket",
     "compat.MixinLinkedControllerStopLecternPacket",
     "compat.tweaked.MixinLecternTweakedBlock",


### PR DESCRIPTION
add an instant var TAG to HubItem
add MixinLecternControllerBlockEntity to ensure LecternControllerBlockEntity has the tag Hub

It is known that Create version 6.0.7 only saves Items on Entities. The code for Create version 0.5.1 was also referenced, and the logic should be correct. It has been tested and works on Create version 6.0.8.
